### PR TITLE
Feat: add french translation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,0 @@
-theme: jekyll-theme-cayman

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-cayman

--- a/inc/languages/French.php
+++ b/inc/languages/French.php
@@ -1,0 +1,122 @@
+<?php
+/*
+    English language for Surftimer-Web-Stats v2.05
+    Translation by: Sarrus
+*/
+
+define('NAVBAR_DASHBOARD', 'Tableau de bord');
+define('NAVBAR_HOME', 'Accueil');
+define('NAVBAR_TOP_PLAYERS', 'Top joueurs');
+define('NAVBAR_MAPS', 'Maps');
+define('NAVBAR_MOST_ACTIVE', 'Plus actifs');
+define('NAVBAR_RECENT_RECORDS', 'Records recents');
+define('NAVBAR_SEARCH_PLAYER', 'Rechercher un joueur');
+
+define('SEARCH_SEARCH_PLAYERS', 'Rechercher parmis les joueurs');
+define('SEARCH_CLOSE', 'Fermer');
+define('SEARCH_INPUT', 'Chercher un joueur par son nom d\'utilisateur, SteamID ou SteamID64');
+define('SEARCH_NO_RESULTS', 'Auncun résultat');
+
+define('HOME_TOTAL_PLAYERS', 'Nombre de joueurs');
+define('HOME_TOTAL_MAPS', 'Nombre de maps');
+define('HOME_TOTAL_BONUSES', 'Nombre de bonus');
+define('HOME_TOTAL_COMPLETIONS', 'Nombre de completions');
+define('HOME_HOURS_PLAYED', 'Heures jouées');
+define('HOME_RECENT', 'Records récents');
+define('HOME_TOP_PLAYERS', 'Top 10 joueurs');
+define('HOME_TOP_WR', 'Top 10 records');
+define('HOME_TOP_BONUS_WR', 'Top 10 records bonus');
+define('HOME_TOP_STAGE_WR', 'Top 10 records stage');
+define('HOME_RECENT_MAPS', 'Maps ajoutées récemment');
+define('HOME_BUTTON_SHOW_MORE', 'Plus');
+
+define('TABLE_USERNAME', 'Nom d\'utilisateur');
+define('TABLE_MAP', 'Map');
+define('TABLE_MAPS', 'Maps');
+define('TABLE_MAP_NAME', 'Nom de map');
+define('TABLE_TIME', 'Temps');
+define('TABLE_DATE', 'Date');
+define('TABLE_POINTS', 'Points');
+define('TABLE_BONUS', 'Bonus');
+define('TABLE_BONUSES', 'Bonus');
+define('TABLE_NO_BONUS', 'Pas de bonus');
+define('TABLE_STAGES', 'Stages');
+define('TABLE_COMPLETIONS', 'Completions');
+define('TABLE_WRS', 'Records');
+define('TABLE_FINISHED_MAPS', 'Maps finies');
+define('TABLE_FINISHED_BONUSES', 'Bonuses finis');
+define('TABLE_FINISHED_STAGES', 'Stages finis');
+define('TABLE_TIER', 'Tier');
+define('TABLE_TYPE', 'Type');
+define('TABLE_ADDED', 'Ajouté');
+define('TABLE_JOINED', 'Rejoins');
+define('TABLE_HOURS', 'Heures');
+define('TABLE_RANK', 'Rang');
+define('TABLE_BONUS_RANK', 'Rang bonus');
+define('TABLE_STAGE_RANK', 'Rang stage');
+define('TABLE_RUNTIME', 'Temps du run');
+define('TABLE_CONNECTIONS', 'Connections');
+define('TABLE_LAST_SEEN', 'Dernière connexion');
+define('TABLE_LINEAR', 'Lineaire');
+define('TABLE_STAGED', 'Staged');
+define('TABLE_NULL', 'Null');
+define('TABLE_TODAY', 'Aujourd\'hui');
+define('TABLE_YESTERDAY', 'Hier');
+define('TABLE_DAYS_AGO', 'days ago');
+define('TABLE_TOP_PLAYER_NAME', 'Nom du meilleur joueur');
+define('TABLE_TOP_TIME', 'Meilleur temps');
+define('TABLE_TOTAL_STAGE_COMPLETIONS', 'Nombre total de completions de stages');
+
+define('MAPS_MAP_COLLECTION', 'Collection de maps');
+define('MAPS_MAX_VELOCITY', 'Vitesse maximale');
+define('MAPS_TOTAL_COMPLETIONS', 'Nombre total de completions');
+define('MAPS_MAP_COMPLETIONS', 'Nombre total de completions de maps');
+define('MAPS_STAGE_COMPLETIONS', 'Nombre total de completions de stages');
+define('MAPS_BONUSES_COMPLETIONS', 'Nombre total de completions de bonus');
+
+define('PROFILE_PLAYER_PROFILE', 'Profile du joueur');
+define('PROFILE_TOP', 'TOP');
+define('PROFILE_USER_TOTAL_COMPLETION_PROGRESS', 'Progression totale du joueur');
+define('PROFILE_OVERALL_RANK', 'Rang global');
+define('PROFILE_TOTAL_PLAYTIME', 'Temps de jeu total');
+define('PROFILE_SURF_TIME', 'Temps de surf');
+define('PROFILE_MAP_COMPLETIONS', 'Nombre de completiosn de maps');
+define('PROFILE_BONUS_COMPLETIONS', 'Nombre de completiosn de bonus');
+define('PROFILE_STAGES_COMPLETIONS', 'Nombre de completiosn de stages');
+define('PROFILE_MAP_TOP_10S', 'Map Top 10s');
+define('PROFILE_BONUS_WR_POINTS', 'Points de records bonus');
+define('PROFILE_MAP_TOP_10S_POINTS', 'Points Map Top 10s');
+define('PROFILE_MAP_POINTS', 'Points de map');
+define('PROFILE_TOTAL_POINTS', 'Points totaux');
+define('PROFILE_TOTAL_CONNECTIONS', 'Connexions totales');
+define('PROFILE_SPEC_TIME', 'Temps de spectating');
+define('PROFILE_MAP_RECORDS', 'Records de maps');
+define('PROFILE_BONUS_RECORDS', 'Records de bonus');
+define('PROFILE_STAGE_RECORDS', 'Records de stages');
+define('PROFILE_MAP_WR_POINTS', 'Points de map WR');
+define('PROFILE_STAGE_WR_POINTS', 'Points de stage WR');
+define('PROFILE_GROUP_POINTS', 'Points de groupes');
+define('PROFILE_BONUS_POINTS', 'Points de bonus');
+define('PROFILE_HRS', 'hrs');
+define('PROFILE_TIER', 'Tier');
+define('PROFILE_PLAYER_COMPLETIONS_BY_MAP_TIER', 'Completions du joueur par Tier de map');
+define('PROFILE_PLAYER_FINISHED_MAPS', 'Maps finies par le joueur');
+define('PROFILE_PLAYER FINISHED_BONUSES', 'Bonus finies par le joueur');
+define('PROFILE_PLAYER_FINISHED_STAGES', 'Stages finies par le joueur');
+
+define('TOP_1000_PLAYERS', 'Top 1,000 Joueurs');
+define('MAP_COLLECTION', 'Collection de Maps');
+define('MOST_ACTIVE', 'Most Active');
+define('RECENT_100_MAP_RECORDS', 'Top 100 des records les plus récents');
+
+define('LOADING_MAP', 'Chargement de la map:');
+define('DETAILS', 'Détails');
+define('PLESE_WAIT', 'Merci de patienter');
+define('LOADING', 'Chargement');
+define('LOADING_MAP_COLLECTION', 'Chargement de la collection de map');
+define('LOADING_MOST_ACTIVE_LIST', 'Chargement de la liste Most Active');
+define('LOADING_PLAYER_PROFILE', 'Chargement du profile du joueur');
+define('LOADING_RECENT_MAP_RECORDS_LIST', 'Chargement de la liste des records récents');
+define('LOADING_TOP_PLAYERS_LIST', 'Chargement de la liste des meilleurs joueurs');
+define('MAP_NOT_ADDED_PROPERLY', 'n\'ont pas été ajouté correctement au serveur, merci de contacter un admin');
+define('NOT_FOUND_IN_DB', 'n\'ont pas été trouvé dans la base de données');


### PR DESCRIPTION
Note that in french there is the masculine and feminine words (he/she), like in spanish.
Here, the translation of "player" uses the masculine "joueur", as the grammar rule is "Masculine wins over feminine".
I would personnaly prefer having " joueur·euse" which is the more inclusive writting, even if it is less commonly used.
Let me know if I should change it.